### PR TITLE
Global Command Bar Implementation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import localFont from 'next/font/local'
 import './globals.css'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import CommandBar from '@/components/CommandBar/CommandBar'
+import { commandActions } from '@/constants/commandActions'
+import { CommandBarProvider } from '@/contexts/CommandBarContext'
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -30,11 +33,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col dark`}
       >
-        <Header />
-        <main className="max-w-7xl w-full flex-grow mx-auto px-4 py-6">
-          {children}
-        </main>
-        <Footer />
+        <CommandBarProvider>
+          <Header />
+          <main className="max-w-7xl w-full flex-grow mx-auto px-4 py-6">
+            {children}
+            <CommandBar actions={commandActions} />
+          </main>
+          <Footer />
+        </CommandBarProvider>
       </body>
     </html>
   )

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { redirect } from 'next/navigation'
 import {
   CommandDialog,
@@ -8,25 +10,25 @@ import {
   CommandShortcut,
 } from '@/components/ui/command'
 import type { CommandAction } from '@/types/command'
+import { useToggleOnKeyCombo } from '@/hooks/useToggleOnKeyCombo'
 
 interface CommandBarProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
   actions: CommandAction[]
 }
 
-export default function CommandBar({
-  open,
-  onOpenChange,
-  actions,
-}: CommandBarProps) {
+export default function CommandBar({ actions }: CommandBarProps) {
+  const [open, toggleCommandBar, closeCommandBar] = useToggleOnKeyCombo({
+    targetKey: 'k',
+    modifiers: { ctrl: true },
+  })
+
   const handleSelect = (action: CommandAction) => {
-    onOpenChange(false)
+    closeCommandBar()
     redirect(action.href as string)
   }
 
   return (
-    <CommandDialog open={open} onOpenChange={onOpenChange}>
+    <CommandDialog open={open} onOpenChange={toggleCommandBar}>
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>

--- a/src/components/CommandBar/CommandBarButton.tsx
+++ b/src/components/CommandBar/CommandBarButton.tsx
@@ -1,24 +1,19 @@
 'use client'
 
 import CommandKey from '@/components/CommandBar/CommandKey'
-import CommandBar from '@/components/CommandBar/CommandBar'
-import { useToggleOnKeyCombo } from '@/hooks/useToggleOnKeyCombo'
-import { commandActions } from '@/constants/commandActions'
 import { Button } from '@/components/ui/button'
 import { ArrowRight } from 'lucide-react'
+import { useCommandBar } from '@/contexts/CommandBarContext'
 
 export default function CommandBarButton() {
-  const [open, setOpen] = useToggleOnKeyCombo({
-    targetKey: 'k',
-    modifiers: { ctrl: true },
-  })
+  const { toggleCommandBar } = useCommandBar()
 
   return (
     <>
       <Button
         variant="ghost"
         className="group transition-all duration-300 ease-in-out"
-        onClick={() => setOpen(!open)}
+        onClick={toggleCommandBar}
       >
         <p className="text-sm text-muted-foreground flex items-center space-x-2 group-hover:text-foreground transition-colors duration-300">
           <span>Press</span>
@@ -27,7 +22,6 @@ export default function CommandBarButton() {
           <ArrowRight className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1" />
         </p>
       </Button>
-      <CommandBar open={open} onOpenChange={setOpen} actions={commandActions} />
     </>
   )
 }

--- a/src/contexts/CommandBarContext.tsx
+++ b/src/contexts/CommandBarContext.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+
+interface CommandBarContext {
+  isOpen: boolean
+  toggleCommandBar: () => void
+  openCommandBar: () => void
+  closeCommandBar: () => void
+}
+
+const CommandBarContext = createContext<CommandBarContext | null>(null)
+
+export const CommandBarProvider: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleCommandBar = () => setIsOpen(prev => !prev)
+  const openCommandBar = () => setIsOpen(true)
+  const closeCommandBar = () => setIsOpen(false)
+
+  return (
+    <CommandBarContext.Provider
+      value={{
+        isOpen,
+        toggleCommandBar,
+        openCommandBar,
+        closeCommandBar,
+      }}
+    >
+      {children}
+    </CommandBarContext.Provider>
+  )
+}
+
+export const useCommandBar = () => {
+  const context = useContext(CommandBarContext)
+
+  if (!context) {
+    throw new Error('useCommandBar must be used within a CommandBarProvider')
+  }
+
+  return context
+}

--- a/src/hooks/useToggleOnKeyCombo.ts
+++ b/src/hooks/useToggleOnKeyCombo.ts
@@ -1,12 +1,15 @@
+  'use client'
+
+import { useCallback, useEffect } from 'react'
 import type { ToggleOnKeyComboOptions } from '@/types/command'
-import { useCallback, useEffect, useState } from 'react'
+import { useCommandBar } from '@/contexts/CommandBarContext'
 
 export function useToggleOnKeyCombo({
   targetKey,
   modifiers = {},
   element,
 }: ToggleOnKeyComboOptions) {
-  const [isActive, setIsActive] = useState(false)
+  const { isOpen, toggleCommandBar, closeCommandBar } = useCommandBar()
 
   const areModifiersPressed = useCallback(
     (event: KeyboardEvent) => {
@@ -30,7 +33,7 @@ export function useToggleOnKeyCombo({
         areModifiersPressed(e)
       ) {
         e.preventDefault()
-        setIsActive(prev => !prev)
+        toggleCommandBar()
       }
     }
 
@@ -42,7 +45,7 @@ export function useToggleOnKeyCombo({
         handleKeyDown as EventListener
       )
     }
-  }, [targetKey, areModifiersPressed, element])
+  }, [targetKey, areModifiersPressed, element, toggleCommandBar])
 
-  return [isActive, setIsActive] as const
+  return [isOpen, toggleCommandBar, closeCommandBar] as const
 }


### PR DESCRIPTION
This PR addresses the issue of the command bar being limited to the home page by implementing a global command bar accessible across all pages.

Changes:

- Added `CommandBar` component to root layout
- Created `CommandBarContext` for state management
- Refactored `CommandBarButton` to use context
- Updated `useToggleOnKeyCombo` hook
- Enhanced UX with centralized access
